### PR TITLE
feat: scaffold pyproject and api stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+## 2026-03-09
+
+### Added
+- Initial `pyproject.toml` metadata and setuptools configuration
+- `src/aulelabs/` package with an API registration placeholder
+- This changelog to track future updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "aulelabs"
+version = "0.1.0"
+description = "Core scaffolding for the AuleLab toolkit."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+  { name = "Andrew Xu" }
+]
+dependencies = []
+
+[project.urls]
+Repository = "https://github.com/Andrew-XQY/AuleLab"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/aulelabs/__init__.py
+++ b/src/aulelabs/__init__.py
@@ -1,0 +1,3 @@
+"""AuleLab core package placeholder."""
+
+__all__ = ["api_registration"]

--- a/src/aulelabs/api_registration.py
+++ b/src/aulelabs/api_registration.py
@@ -1,0 +1,29 @@
+"""API registration stubs for future orchestrators.
+
+This module will eventually expose helpers that register high-level
+interfaces (CLI commands, HTTP endpoints, notebooks, etc.) with whatever
+runtime the toolkit is plugged into. For now it just documents the intent
+so contributors know where to add their hooks.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class Registry(Protocol):
+    """Shallow protocol representing whatever registry we plug into."""
+
+    def add(self, name: str, handler: Any, /, **metadata: Any) -> None:  # pragma: no cover - placeholder
+        ...
+
+
+def register_api(registry: Registry) -> None:
+    """Register AuleLab API surfaces with *registry*.
+
+    In the short term this function will probably wire CLI commands and
+    service endpoints. For now it simply documents what needs to happen so
+    future contributors have a single touch point.
+    """
+
+    # TODO: wire up real handlers once the orchestration surface is defined.
+    registry.add("aulelabs.placeholder", lambda **_: None, purpose="bootstrap stub")


### PR DESCRIPTION
## Summary
- flesh out `pyproject.toml` with basic metadata and setuptools config
- add `src/aulelabs/api_registration.py` placeholder plus package init
- start a `CHANGELOG.md` describing today's changes

## Testing
- not run (scaffolding-only change)
